### PR TITLE
xadd-maxlen-support

### DIFF
--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -18,7 +18,11 @@ interface RedisStreamOptionsXreadGroup {
   deleteMessagesAfterAck?: boolean;
 }
 
-export type RedisStreamOptions = RedisStreamOptionsXreadGroup;
+interface RedisStreamOptionsXadd {
+  maxLen?: number;
+}
+
+export type RedisStreamOptions = RedisStreamOptionsXreadGroup & RedisStreamOptionsXadd;
 
 // [id, [key, value, key, value]]
 export type RawStreamMessage = [id: string, payload: string[]];

--- a/lib/redis.client.ts
+++ b/lib/redis.client.ts
@@ -7,6 +7,7 @@ import { RequestsMap } from './requests-map';
 import { deserialize, generateCorrelationId, serialize } from './streams.utils';
 import { RedisStreamContext } from './stream.context';
 import { firstValueFrom, share } from 'rxjs';
+import { RedisValue } from 'ioredis';
 
 @Injectable()
 export class RedisStreamClient extends ClientProxy {
@@ -104,9 +105,16 @@ export class RedisStreamClient extends ClientProxy {
     try {
       if (!this.client) throw new Error('Redis client instance not found.');
 
+      const commandArgs: RedisValue[] = [];
+      if(this.options.streams?.maxLen){
+        commandArgs.push("MAXLEN")
+        commandArgs.push("~")
+        commandArgs.push(this.options.streams.maxLen.toString())
+      }
+      commandArgs.push("*")
       let response = await this.client.xadd(
         stream,
-        '*',
+        ...commandArgs,
         ...serializedPayloadArray,
       );
       return response;


### PR DESCRIPTION
The lib does not currently support MAXLEN, which is crucial in making sure that you don't experience an out of memory error if you aren't using the  deleteAfterAck option.

We ran into this issue in our testing, and found others may gain from the change. See the note on "Capped Streams" here: https://redis.io/docs/latest/commands/xadd
